### PR TITLE
show both timetables and be able to regenerate

### DIFF
--- a/src/main/java/Generator/InterfaceAdapter/display_timetable/DisplayTimetableController.java
+++ b/src/main/java/Generator/InterfaceAdapter/display_timetable/DisplayTimetableController.java
@@ -2,19 +2,27 @@ package Generator.InterfaceAdapter.display_timetable;
 
 
 import Generator.UseCase.generate_timetable.GenerateTimetableInputBoundary;
+import Generator.UseCase.regenerate_timetable.RegenerateTimetableInputBoundary;
 import Generator.UseCase.return_to_prefs.ReturnToPrefsInputBoundary;
 
 public class DisplayTimetableController {
     private final GenerateTimetableInputBoundary generateTimeTableInteractor;
     private final ReturnToPrefsInputBoundary returnToPrefsInteractor;
+    private final RegenerateTimetableInputBoundary regenerateTimeTableInteractor;
 
     public DisplayTimetableController(GenerateTimetableInputBoundary generateTimeTableInteractor,
-                                      ReturnToPrefsInputBoundary returnToPrefsInteractor) {
+                                      ReturnToPrefsInputBoundary returnToPrefsInteractor,
+                                      RegenerateTimetableInputBoundary regenerateTimeTableInteractor) {
         this.generateTimeTableInteractor = generateTimeTableInteractor;
         this.returnToPrefsInteractor = returnToPrefsInteractor;
+        this.regenerateTimeTableInteractor = regenerateTimeTableInteractor;
     }
 
     public void returnToPrefs() {
         returnToPrefsInteractor.execute();
+    }
+
+    public void regenerateTimetable() {
+        regenerateTimeTableInteractor.execute();
     }
 }

--- a/src/main/java/Generator/InterfaceAdapter/display_timetable/DisplayTimetablePresenter.java
+++ b/src/main/java/Generator/InterfaceAdapter/display_timetable/DisplayTimetablePresenter.java
@@ -2,11 +2,10 @@ package Generator.InterfaceAdapter.display_timetable;
 
 import Generator.InterfaceAdapter.ViewManagerModel;
 import Generator.InterfaceAdapter.set_preferences.SetPreferencesViewModel;
-import Generator.UseCase.generate_timetable.GenerateTimetableOutputBoundary;
-import Generator.UseCase.generate_timetable.GenerateTimetableOutputData;
+import Generator.UseCase.regenerate_timetable.RegenerateTimetableOutputBoundary;
 import Generator.UseCase.return_to_prefs.ReturnToPrefsOutputBoundary;
 
-public class DisplayTimetablePresenter implements ReturnToPrefsOutputBoundary {
+public class DisplayTimetablePresenter implements ReturnToPrefsOutputBoundary, RegenerateTimetableOutputBoundary {
     private final ViewManagerModel viewManagerModel;
     private final DisplayTimetableViewModel displayTimeTableViewModel;
     private final SetPreferencesViewModel setPreferencesViewModel;
@@ -23,5 +22,12 @@ public class DisplayTimetablePresenter implements ReturnToPrefsOutputBoundary {
     public void prepareReturnToPrefsSuccessView() {
         viewManagerModel.setState(setPreferencesViewModel.getViewName());
         viewManagerModel.firePropertyChange();
+    }
+
+    @Override
+    public void prepareRegenerateSuccessView() {
+        final DisplayTimetableState displayTimetableState = displayTimeTableViewModel.getState();
+        displayTimetableState.changeTimetableIndex();
+        displayTimeTableViewModel.firePropertyChange();
     }
 }

--- a/src/main/java/Generator/InterfaceAdapter/display_timetable/DisplayTimetableState.java
+++ b/src/main/java/Generator/InterfaceAdapter/display_timetable/DisplayTimetableState.java
@@ -1,6 +1,5 @@
 package Generator.InterfaceAdapter.display_timetable;
 
-import CourseInfo.Section;
 import Generator.UseCase.generate_timetable.TimetableDTO;
 
 import java.util.ArrayList;
@@ -14,13 +13,12 @@ import java.util.ArrayList;
 public class DisplayTimetableState {
     private ArrayList<String> courseCodes = new ArrayList<>();
     private ArrayList<String> courseNames = new ArrayList<>();
-    private ArrayList<ArrayList<Section>> lectureSections = new ArrayList<>();
-    private ArrayList<ArrayList<Section>> tutorialSections = new ArrayList<>();
-    private ArrayList<ArrayList<Section>> practicalSections = new ArrayList<>();
     private ArrayList<Double> credit = new ArrayList<>();
-    private ArrayList<String> sessionCode = new ArrayList<>();
     private String noCourseError;
-    private ArrayList<TimetableDTO>  allTimeTables;
+    private ArrayList<TimetableDTO> fallTimetables;
+    private ArrayList<TimetableDTO> winterTimetables;
+    private int fallIndex = 0;
+    private int winterIndex = 0;
 
     public DisplayTimetableState() {
     }
@@ -31,55 +29,36 @@ public class DisplayTimetableState {
     public ArrayList<String > getCourseNames() {
         return courseNames;
     }
-
-
-    public ArrayList<ArrayList<Section>> getLectureSections() {
-        return lectureSections;
-    }
-    public ArrayList<ArrayList<Section>> getTutorialSections() {
-        return tutorialSections;
-    }
-    public ArrayList<ArrayList<Section>> getPracticalSections() {
-        return practicalSections;
-    }
     public ArrayList<Double> getCredit() {
         return credit;
-    }
-    public ArrayList<String> getSessionCode() {
-        return sessionCode;
     }
     public String getNoCourseError() {
         return noCourseError;
     }
-    public ArrayList<TimetableDTO> getAllTimeTables() {
-        return allTimeTables;
+    public ArrayList<TimetableDTO> getFallTimetables() {
+        return fallTimetables;
     }
+    public ArrayList<TimetableDTO> getWinterTimetables() {
+        return winterTimetables;
+    }
+
     public void setCourses(ArrayList<String> courses) {
         this.courseCodes = courses;
     }
     public void setCourseNames(ArrayList<String> courseNames) {
         this.courseNames = courseNames;
     }
-    public void setLectureSections(ArrayList<ArrayList<Section>> lectureSections) {
-        this.lectureSections = lectureSections;
-    }
-    public void setTutorialSections(ArrayList<ArrayList<Section>> tutorialSections) {
-        this.tutorialSections = tutorialSections;
-    }
-    public void setPracticalSections(ArrayList<ArrayList<Section>> practicalSections) {
-        this.practicalSections = practicalSections;
-    }
     public void setCredit(ArrayList<Double> credit) {
         this.credit = credit;
-    }
-    public void setSessionCode(ArrayList<String> sessionCode) {
-        this.sessionCode = sessionCode;
     }
     public void setNoCourseError(String noCourseError) {
         this.noCourseError = noCourseError;
     }
-    public void setAllTimeTables (ArrayList<TimetableDTO>  allTimeTables) {
-        this.allTimeTables = allTimeTables;
+    public void setFallTimetables(ArrayList<TimetableDTO> fallTimetables) {
+        this.fallTimetables = fallTimetables;
+    }
+    public void setWinterTimetables(ArrayList<TimetableDTO> winterTimetables) {
+        this.winterTimetables = winterTimetables;
     }
 
     public void addCourseName(String courseName) {
@@ -88,30 +67,43 @@ public class DisplayTimetableState {
     public void addCourseCode(String courseCode) {
         this.courseCodes.add(courseCode);
     }
-    public void addLectureSection(ArrayList<Section> section) {
-        this.lectureSections.add(section);
-    }
-    public void addTutorialSection(ArrayList<Section> section) {
-        this.tutorialSections.add(section);
-    }
-    public void addPracticalSection(ArrayList<Section> section) {
-        this.practicalSections.add(section);
-    }
     public void addCredit(Double credit) {
         this.credit.add(credit);
     }
-    public void addSessionCode(String sessionCode) {
-        this.sessionCode.add(sessionCode);
-    }
+
     public void removeCourse(String courseCode) {
         int index = this.courseCodes.indexOf(courseCode);
         this.courseCodes.remove(index);
         this.courseNames.remove(index);
-        this.lectureSections.remove(index);
-        this.tutorialSections.remove(index);
-        this.practicalSections.remove(index);
         this.credit.remove(index);
-        this.sessionCode.remove(index);
+    }
+
+    /**
+     * currently just goes to the next timetable in the arraylist
+     */
+    public void changeTimetableIndex() {
+        fallIndex++;
+        winterIndex++;
+
+        if (fallIndex >= fallTimetables.size()) {
+            fallIndex = 0;
+        }
+        if (winterIndex >= winterTimetables.size()) {
+            winterIndex = 0;
+        }
+    }
+
+    public void resetTimetableIndex() {
+        fallIndex = 0;
+        winterIndex = 0;
+    }
+
+    public int getFallIndex() {
+        return fallIndex;
+    }
+
+    public int getWinterIndex() {
+        return winterIndex;
     }
 }
 

--- a/src/main/java/Generator/InterfaceAdapter/set_preferences/SetPreferencesPresenter.java
+++ b/src/main/java/Generator/InterfaceAdapter/set_preferences/SetPreferencesPresenter.java
@@ -37,12 +37,8 @@ public class SetPreferencesPresenter implements AddCourseOutputBoundary, RemoveC
         final DisplayTimetableState displayTimetableState = displayTimetableViewModel.getState();
         displayTimetableState.addCourseCode(addCourseOutputData.getCourseCode());
         displayTimetableState.addCourseName(addCourseOutputData.getCourseName());
-        displayTimetableState.addLectureSection(addCourseOutputData.getLectureSection());
-        displayTimetableState.addTutorialSection(addCourseOutputData.getTutorialSection());
-        displayTimetableState.addPracticalSection(addCourseOutputData.getPracticalSection());
         displayTimetableState.addCredit(addCourseOutputData.getCredit());
-        displayTimetableState.addSessionCode(addCourseOutputData.getSessionCode());
-        displayTimetableViewModel.firePropertyChange();
+        displayTimetableState.resetTimetableIndex();
 
         viewManagerModel.setState(setPreferencesViewModel.getViewName());
         viewManagerModel.firePropertyChange();
@@ -68,7 +64,7 @@ public class SetPreferencesPresenter implements AddCourseOutputBoundary, RemoveC
 
         final DisplayTimetableState displayTimetableState = displayTimetableViewModel.getState();
         displayTimetableState.removeCourse(removeCourseOutputData.getCourse());
-        displayTimetableViewModel.firePropertyChange();
+        displayTimetableState.resetTimetableIndex();
 
         viewManagerModel.setState(setPreferencesViewModel.getViewName());
         viewManagerModel.firePropertyChange();
@@ -112,6 +108,11 @@ public class SetPreferencesPresenter implements AddCourseOutputBoundary, RemoveC
         final SetPreferencesState setPreferencesState = setPreferencesViewModel.getState();
         setPreferencesState.setNoSelectedCoursesError(null);
         setPreferencesViewModel.firePropertyChange();
+
+        final DisplayTimetableState displayTimetableState = displayTimetableViewModel.getState();
+        displayTimetableState.setFallTimetables(generateTimetableOutputData.getFallTimeTables());
+        displayTimetableState.setWinterTimetables(generateTimetableOutputData.getWinterTimeTables());
+        displayTimetableViewModel.firePropertyChange();
 
         viewManagerModel.setState(displayTimetableViewModel.getViewName());
         viewManagerModel.firePropertyChange();

--- a/src/main/java/Generator/UseCase/regenerate_timetable/RegenerateTimetableInputBoundary.java
+++ b/src/main/java/Generator/UseCase/regenerate_timetable/RegenerateTimetableInputBoundary.java
@@ -1,0 +1,5 @@
+package Generator.UseCase.regenerate_timetable;
+
+public interface RegenerateTimetableInputBoundary {
+    void execute();
+}

--- a/src/main/java/Generator/UseCase/regenerate_timetable/RegenerateTimetableInteractor.java
+++ b/src/main/java/Generator/UseCase/regenerate_timetable/RegenerateTimetableInteractor.java
@@ -1,0 +1,14 @@
+package Generator.UseCase.regenerate_timetable;
+
+public class RegenerateTimetableInteractor implements RegenerateTimetableInputBoundary {
+
+    private final RegenerateTimetableOutputBoundary regenerateTimetableOutputBoundary;
+
+    public RegenerateTimetableInteractor(RegenerateTimetableOutputBoundary regenerateTimetableOutputBoundary) {
+        this.regenerateTimetableOutputBoundary = regenerateTimetableOutputBoundary;
+    }
+
+    public void execute() {
+        regenerateTimetableOutputBoundary.prepareRegenerateSuccessView();
+    }
+}

--- a/src/main/java/Generator/UseCase/regenerate_timetable/RegenerateTimetableOutputBoundary.java
+++ b/src/main/java/Generator/UseCase/regenerate_timetable/RegenerateTimetableOutputBoundary.java
@@ -1,0 +1,5 @@
+package Generator.UseCase.regenerate_timetable;
+
+public interface RegenerateTimetableOutputBoundary {
+    void prepareRegenerateSuccessView();
+}

--- a/src/main/java/app/AppBuilder.java
+++ b/src/main/java/app/AppBuilder.java
@@ -14,6 +14,9 @@ import Generator.UseCase.add_course.AddCourseOutputBoundary;
 import Generator.UseCase.generate_timetable.GenerateTimetableInputBoundary;
 import Generator.UseCase.generate_timetable.GenerateTimetableInteractor;
 import Generator.UseCase.generate_timetable.GenerateTimetableOutputBoundary;
+import Generator.UseCase.regenerate_timetable.RegenerateTimetableInputBoundary;
+import Generator.UseCase.regenerate_timetable.RegenerateTimetableInteractor;
+import Generator.UseCase.regenerate_timetable.RegenerateTimetableOutputBoundary;
 import Generator.UseCase.remove_course.RemoveCourseInputBoundary;
 import Generator.UseCase.remove_course.RemoveCourseInteractor;
 import Generator.UseCase.remove_course.RemoveCourseOutputBoundary;
@@ -100,15 +103,20 @@ public class AppBuilder {
                 displayTimetableViewModel, setPreferencesViewModel);
         final ReturnToPrefsInputBoundary returnToPrefsInteractor
                 = new ReturnToPrefsInteractor(returnToPrefsOutputBoundary);
-        DisplayTimetableController displayTimetableController
-                = new DisplayTimetableController(generateTimetableInteractor, returnToPrefsInteractor);
+        final RegenerateTimetableOutputBoundary regenerateTimetableOutputBoundary = new
+                DisplayTimetablePresenter(viewManagerModel, displayTimetableViewModel, setPreferencesViewModel);
+        final RegenerateTimetableInputBoundary regenerateTimetableInteractor = new
+                RegenerateTimetableInteractor(regenerateTimetableOutputBoundary);
+        DisplayTimetableController displayTimetableController = new
+                DisplayTimetableController(generateTimetableInteractor, returnToPrefsInteractor,
+                regenerateTimetableInteractor);
         displayTimetableView.setDisplayTimetableController(displayTimetableController);
         return this;
     }
 
     public JFrame build() {
-        final JFrame application = new JFrame("sdjkfsjdkdjfksjkdfk");
-        application.setMinimumSize(new Dimension(800, 400));
+        final JFrame application = new JFrame("Timetable Builder, but better");
+        application.setMinimumSize(new Dimension(1500, 600));
         application.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
         application.add(cardPanel);


### PR DESCRIPTION
- modified the timetable view so it actually depends on the generate timetable interactor

- modified the timetable view to show both fall and winter timetables

- time text is now aligned right and course text is aligned center

- course colors have been standardized (to a degree)

- finished the regenerate use case, which displays a new timetable every time it is clicked

- changed the default size of the app to fit both timetables